### PR TITLE
🪳 Use REBASE_TOKEN for dependabot-make-release PR operations

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Merge dependabot-updates PR into main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REBASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           PR_STATE=$(gh pr view dependabot-updates --json state --jq '.state')


### PR DESCRIPTION
## Summary

- `dependabot-make-release.yml` was using `github.token` (GITHUB_TOKEN) to create and merge the weekly dependency PR. GitHub intentionally won't trigger other workflow runs from events caused by GITHUB_TOKEN (to prevent infinite loops), so the `pull_request` event never fired, CI never started, and the checks poll loop would time out waiting for checks that never appeared.
- Switched to `REBASE_TOKEN` (PAT) so that `gh pr create` triggers a real `pull_request` event and CI runs normally before the merge.

## Test Plan

- [ ] Confirm `REBASE_TOKEN` secret is set on the repo
- [ ] Trigger `dependabot-make-release` manually via `workflow_dispatch` and verify CI runs on the created PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)