### PR TITLE
🪳 Fix Docker build, ElasticSearch indexing, and staging deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore: [main]
+    branches: [dependabot-updates]
   pull_request:
     branches: ["**"]
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
             mv public/build/manifest.json.new public/build/manifest.json
             docker compose exec -T app php artisan migrate --force || {
               echo "ERROR: Migration failed"
+              docker compose exec -T app php artisan migrate:status || true
               exit 1
             }
             docker compose exec -T app php artisan db:seed --force || {
@@ -219,5 +220,6 @@ jobs:
             mv public/build/manifest.json.new public/build/manifest.json
             docker compose exec -T app php artisan migrate --force || {
               echo "ERROR: Migration failed"
+              docker compose exec -T app php artisan migrate:status || true
               exit 1
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [dependabot-updates]
+    branches-ignore: [main]
   pull_request:
     branches: ["**"]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -34,9 +34,11 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     if: |
-      github.ref != 'refs/heads/dependabot-updates' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      !github.event.pull_request.draft
+      (github.event_name == 'pull_request' &&
+       !github.event.pull_request.draft &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
         required: true
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ inputs.tag || github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ inputs.tag == '' }}
 
 env:
   REGISTRY: ghcr.io
@@ -142,8 +142,13 @@ jobs:
               echo "ERROR: docker compose cp failed. Existing assets preserved."
               exit 1
             }
+            docker compose cp app:/var/www/html/public/build/manifest.json public/build/manifest.json.new || {
+              echo "ERROR: docker compose cp manifest.json failed. Existing assets preserved."
+              exit 1
+            }
             rm -rf public/build/assets
             mv public/build/assets.new public/build/assets
+            mv public/build/manifest.json.new public/build/manifest.json
             docker compose exec -T app php artisan migrate --force || {
               echo "ERROR: Migration failed"
               exit 1
@@ -201,8 +206,13 @@ jobs:
               echo "ERROR: docker compose cp failed. Existing assets preserved."
               exit 1
             }
+            docker compose cp app:/var/www/html/public/build/manifest.json public/build/manifest.json.new || {
+              echo "ERROR: docker compose cp manifest.json failed. Existing assets preserved."
+              exit 1
+            }
             rm -rf public/build/assets
             mv public/build/assets.new public/build/assets
+            mv public/build/manifest.json.new public/build/manifest.json
             docker compose exec -T app php artisan migrate --force || {
               echo "ERROR: Migration failed"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,12 @@ jobs:
               fi
               if [ "$i" -eq 30 ]; then
                 echo "ERROR: Container failed to become ready after 30 attempts"
+                echo "--- Final readiness check output ---"
+                docker compose exec -T app php artisan --version || true
                 docker compose logs --tail=50 app
                 exit 1
               fi
-              echo "Attempt ${i}/30: waiting..."
+              echo "Attempt ${i}/30: container not ready, waiting..."
               sleep 2
             done
             docker compose exec -T app test -d /var/www/html/public/build/assets || {
@@ -196,10 +198,12 @@ jobs:
               fi
               if [ "$i" -eq 30 ]; then
                 echo "ERROR: Container failed to become ready after 30 attempts"
+                echo "--- Final readiness check output ---"
+                docker compose exec -T app php artisan --version || true
                 docker compose logs --tail=50 app
                 exit 1
               fi
-              echo "Attempt ${i}/30: waiting..."
+              echo "Attempt ${i}/30: container not ready, waiting..."
               sleep 2
             done
             docker compose exec -T app test -d /var/www/html/public/build/assets || {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [dependabot-updates]
   pull_request:
     branches: ["**"]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -35,7 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.ref != 'refs/heads/dependabot-updates' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      !github.event.pull_request.draft
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
               echo "ERROR: Migration failed"
               exit 1
             }
+            docker compose exec -T app php artisan db:seed --force || {
+              echo "ERROR: Seeding failed"
+              exit 1
+            }
 
   deploy-production:
     needs: build-and-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG APP_ENV=production
 
 # System dependencies
 RUN apk add --no-cache \
+    bash \
     git \
     unzip \
     curl \
@@ -42,8 +43,7 @@ RUN for dir in /etc/ImageMagick-6 /etc/ImageMagick-7; do \
 # PDFBox jar (latest 3.x via Apache projects API)
 COPY docker/pdfbox/install_pdfbox.sh /tmp/install_pdfbox.sh
 RUN mkdir -p /usr/share/java \
-    && chmod +x /tmp/install_pdfbox.sh \
-    && /tmp/install_pdfbox.sh \
+    && bash /tmp/install_pdfbox.sh \
     && rm /tmp/install_pdfbox.sh
 
 COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache \
         imagemagick-dev \
     && install-php-extensions \
         imagick \
+        pdo_mysql \
+        pdo_sqlite \
         redis \
         pcntl \
         opcache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:22-alpine AS node-deps
+FROM node:22-alpine AS node-build
 WORKDIR /var/www/html
 COPY package.json package-lock.json ./
 RUN npm ci
+COPY . .
+ARG APP_ENV=production
+RUN npm run build
 
 FROM dunglas/frankenphp:1-php8.4-alpine
 WORKDIR /var/www/html
@@ -59,15 +62,12 @@ RUN mkdir -p \
 COPY composer.json composer.lock ./
 RUN composer install --no-dev --optimize-autoloader --no-scripts --no-interaction
 
-# Node dependencies + Vite build
-COPY --from=node-deps /var/www/html/node_modules node_modules
 COPY . .
+COPY --from=node-build /var/www/html/public/build public/build
 RUN cp .env.example .env \
     && php artisan key:generate --force \
     && php artisan package:discover --ansi \
-    && APP_ENV=$APP_ENV npm run build \
-    && rm .env \
-    && rm -rf node_modules
+    && rm .env
 
 # Permissions
 RUN chown -R www-data:www-data storage bootstrap/cache public \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 
 # PHP dependencies
 COPY composer.json composer.lock ./
-RUN composer install --no-dev --optimize-autoloader --no-scripts --no-interaction
+RUN mkdir -p database/seeds database/factories \
+    && composer install --no-dev --optimize-autoloader --no-scripts --no-interaction
 
 # Node dependencies + Vite build
 COPY --from=node-deps /var/www/html/node_modules node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,21 @@ RUN mkdir -p /usr/share/java \
 
 COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 
+# Create all directories Laravel needs before any PHP/composer commands run
+RUN mkdir -p \
+    bootstrap/cache \
+    database/seeds \
+    database/factories \
+    storage/framework/cache \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/logs \
+    storage/app/public \
+    storage/app/thumbnails
+
 # PHP dependencies
 COPY composer.json composer.lock ./
-RUN mkdir -p database/seeds database/factories \
-    && composer install --no-dev --optimize-autoloader --no-scripts --no-interaction
+RUN composer install --no-dev --optimize-autoloader --no-scripts --no-interaction
 
 # Node dependencies + Vite build
 COPY --from=node-deps /var/www/html/node_modules node_modules
@@ -59,9 +70,7 @@ RUN cp .env.example .env \
     && rm -rf node_modules
 
 # Permissions
-RUN mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views \
-             storage/logs storage/app/public storage/app/thumbnails bootstrap/cache \
-    && chown -R www-data:www-data storage bootstrap/cache public \
+RUN chown -R www-data:www-data storage bootstrap/cache public \
     && chmod -R 775 storage bootstrap/cache
 
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ COPY . .
 COPY --from=node-build /var/www/html/public/build public/build
 RUN cp .env.example .env \
     && php artisan key:generate --force \
+    && composer dump-autoload --optimize \
     && php artisan package:discover --ansi \
     && rm .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,15 @@ RUN cp .env.example .env \
     && rm .env
 
 # Permissions
-RUN chown -R www-data:www-data storage bootstrap/cache public database \
-    && chmod -R 775 storage bootstrap/cache database
+# database/ is chowned non-recursively so PHP files (migrations/seeds/factories)
+# stay root-owned and non-writable; only the dir + sqlite file need www-data access.
+RUN chown -R www-data:www-data storage bootstrap/cache public \
+    && chmod -R 775 storage bootstrap/cache \
+    && chown www-data:www-data database \
+    && chmod 775 database \
+    && touch database/database.sqlite \
+    && chown www-data:www-data database/database.sqlite \
+    && chmod 664 database/database.sqlite
 
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     git \
     unzip \
     curl \
+    jq \
     openjdk21-jre-headless \
     imagemagick \
     ghostscript \
@@ -33,12 +34,12 @@ RUN for dir in /etc/ImageMagick-6 /etc/ImageMagick-7; do \
       mkdir -p "$dir" && cp /tmp/imagemagick-policy.xml "$dir/policy.xml"; \
     done && rm /tmp/imagemagick-policy.xml
 
-# PDFBox jar (pinned version for reproducible builds)
+# PDFBox jar (latest 3.x via Apache projects API)
+COPY docker/pdfbox/install_pdfbox.sh /tmp/install_pdfbox.sh
 RUN mkdir -p /usr/share/java \
-    && curl -fL "https://dlcdn.apache.org/pdfbox/3.0.4/pdfbox-app-3.0.4.jar" \
-         -o /usr/share/java/pdfbox.jar \
-    && echo "f598c2e9ce0aee0a11e5a36a15cf06fe534212033fbc984a86ff4d2ff10a73b6c71ca61762d8b527f065a23ffb19e7011ac097865196d4f9490827133fae69cf  /usr/share/java/pdfbox.jar" \
-         | sha512sum -c -
+    && chmod +x /tmp/install_pdfbox.sh \
+    && /tmp/install_pdfbox.sh \
+    && rm /tmp/install_pdfbox.sh
 
 COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ RUN cp .env.example .env \
     && rm .env
 
 # Permissions
-RUN chown -R www-data:www-data storage bootstrap/cache public \
-    && chmod -R 775 storage bootstrap/cache
+RUN chown -R www-data:www-data storage bootstrap/cache public database \
+    && chmod -R 775 storage bootstrap/cache database
 
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -33,7 +33,12 @@ class Handler extends ExceptionHandler
         if ($exception instanceof NoNodesAvailableException) {
             $host = config('elasticsearch.connections.default.hosts.0.host', 'unknown');
             $port = config('elasticsearch.connections.default.hosts.0.port', 9200);
-            Log::error("[ElasticSearch] Cannot connect to {$host}:{$port} — check storage/logs/elasticsearch.log for ES transport details");
+            $scheme = config('elasticsearch.connections.default.hosts.0.scheme', 'null(default http)');
+            $user = config('elasticsearch.connections.default.hosts.0.user') ? 'SET' : 'UNSET';
+            $pass = config('elasticsearch.connections.default.hosts.0.pass') ? 'SET' : 'UNSET';
+            $ssl = config('elasticsearch.connections.default.sslVerification', 'null(system CA)');
+
+            Log::error("[ElasticSearch] Cannot connect — scheme={$scheme} host={$host}:{$port} user={$user} pass={$pass} sslVerification={$ssl} — see storage/logs/elasticsearch.log for transport details");
         }
 
         parent::report($exception);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -33,7 +33,7 @@ class Handler extends ExceptionHandler
         if ($exception instanceof NoNodesAvailableException) {
             $host = config('elasticsearch.connections.default.hosts.0.host', 'unknown');
             $port = config('elasticsearch.connections.default.hosts.0.port', 9200);
-            Log::error("[ElasticSearch] Cannot connect to {$host}:{$port} — check storage/logs/elasticsearch.log for transport details");
+            Log::error("[ElasticSearch] Cannot connect to {$host}:{$port} — check storage/logs/elasticsearch.log for ES transport details");
         }
 
         parent::report($exception);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,8 +2,10 @@
 
 namespace App\Exceptions;
 
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -28,6 +30,12 @@ class Handler extends ExceptionHandler
      */
     public function report(Throwable $exception)
     {
+        if ($exception instanceof NoNodesAvailableException) {
+            $host = config('elasticsearch.connections.default.hosts.0.host', 'unknown');
+            $port = config('elasticsearch.connections.default.hosts.0.port', 9200);
+            Log::error("[ElasticSearch] Cannot connect to {$host}:{$port} — check storage/logs/elasticsearch.log for transport details");
+        }
+
         parent::report($exception);
 
     }// end report()

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Interfaces/IndexerInterface.php
+++ b/app/Interfaces/IndexerInterface.php
@@ -47,6 +47,4 @@ interface IndexerInterface
     public function getLocalFilename($doc);
 
     public function updateSingleField($document, $field, $value);
-
-    public function sweepPages($bar);
 }// end interface

--- a/app/Service/Indexer/ElasticSearch.php
+++ b/app/Service/Indexer/ElasticSearch.php
@@ -663,6 +663,40 @@ class ElasticSearch implements IndexerInterface
         ElasticSearchClient::update($params);
     } // end updateSingleField()
 
+    public function sweepPages($bar)
+    {
+        $size = 100;
+        $searchAfter = false;
+        $documentCache = [];
+        $this->openPointInTime();
+
+        while (true) {
+            $pages = $this->fetchAllPages(false, $size, $searchAfter);
+            if (count($pages['hits']['hits']) == 0) {
+                break;
+            }
+
+            foreach ($pages['hits']['hits'] as $page) {
+                $pageId = $page['_id'];
+                $docId = $page['_source']['path'] ?? null;
+
+                if ($docId !== null) {
+                    if (! array_key_exists($docId, $documentCache)) {
+                        $documentCache[$docId] = (bool) $this->fetchDocument($docId);
+                    }
+
+                    if (! $documentCache[$docId]) {
+                        $this->deletePage($pageId);
+                        $bar ? $bar->setMessage(' Deleted '.$pageId) : null;
+                    }
+                }
+
+                $bar ? $bar->advance() : null;
+                $searchAfter = $page['sort'];
+            }
+        }
+    } // end sweepPages()
+
     public function __destruct()
     {
         if ($this->pointInTime) {

--- a/app/Service/Indexer/ElasticSearch.php
+++ b/app/Service/Indexer/ElasticSearch.php
@@ -661,42 +661,6 @@ class ElasticSearch implements IndexerInterface
         ElasticSearchClient::update($params);
     } // end updateSingleField()
 
-    public function sweepPages($bar)
-    {
-        $size = 100;
-        $searchAfter = false;
-        $documentCache = [];
-        $this->openPointInTime();
-
-        while (true) {
-            $pages = $this->fetchAllPages(false, $size, $searchAfter);
-            if (count($pages['hits']['hits']) == 0) {
-                break;
-            }
-
-            foreach ($pages['hits']['hits'] as $page) {
-                $pageId = $page['_id'];
-                $docId = $page['_source']['path'] ?? null;
-
-                if ($docId === null) {
-                    Log::warning("[SweepPages] Page {$pageId} has no 'path' in _source — skipping (possible orphan)");
-                } else {
-                    if (! array_key_exists($docId, $documentCache)) {
-                        $documentCache[$docId] = (bool) $this->fetchDocument($docId);
-                    }
-
-                    if (! $documentCache[$docId]) {
-                        $this->deletePage($pageId);
-                        $bar ? $bar->setMessage(' Deleted '.$pageId) : null;
-                    }
-                }
-
-                $bar ? $bar->advance() : null;
-                $searchAfter = $page['sort'];
-            }
-        }
-    } // end sweepPages()
-
     public function __destruct()
     {
         if ($this->pointInTime) {

--- a/app/Service/Indexer/ElasticSearch.php
+++ b/app/Service/Indexer/ElasticSearch.php
@@ -627,11 +627,9 @@ class ElasticSearch implements IndexerInterface
     private function closePointInTime()
     {
         $params = [
-            // 'index' => $this->elasticSearchIndex,
             'id' => $this->pointInTime,
         ];
-        // $response = ElasticSearchClient::closePointInTime($params);
-
+        ElasticSearchClient::closePointInTime($params);
     } // end closePointInTime()
 
     public function getDocThumbnail($doc)
@@ -680,7 +678,9 @@ class ElasticSearch implements IndexerInterface
                 $pageId = $page['_id'];
                 $docId = $page['_source']['path'] ?? null;
 
-                if ($docId !== null) {
+                if ($docId === null) {
+                    Log::warning("[SweepPages] Page {$pageId} has no 'path' in _source — skipping (possible orphan)");
+                } else {
                     if (! array_key_exists($docId, $documentCache)) {
                         $documentCache[$docId] = (bool) $this->fetchDocument($docId);
                     }

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
 use Monolog\Level;
 
 return [
@@ -92,8 +93,8 @@ return [
              */
             'logging' => true,
 
-            // If you have an existing instance of Monolog you can use it here.
-            // 'logObject' => \Log::getMonolog(),
+            // Route ES transport logs through Laravel so they appear alongside app logs
+            'logObject' => Log::getLogger(),
 
             'logPath' => storage_path('logs/elasticsearch.log'),
 

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Log;
 use Monolog\Level;
 
 return [
@@ -93,8 +92,10 @@ return [
              */
             'logging' => true,
 
-            // Route ES transport logs through Laravel so they appear alongside app logs
-            'logObject' => Log::getLogger(),
+            // logObject cannot be set here — config:cache serialises this array via var_export()
+            // and a Logger instance (with closures/handlers) is not serialisable. Transport logs
+            // go to logPath instead; Handler.php adds host context to the Laravel log on failure.
+            'logObject' => null,
 
             'logPath' => storage_path('logs/elasticsearch.log'),
 

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -13,7 +13,8 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('users')->insert([
+        // TODO: replace hardcoded password with an env var (APP_SEED_PASSWORD)
+        DB::table('users')->insertOrIgnore([
             'name' => 'Aquarion',
             'email' => 'nicholas@aquarionics.com',
             'password' => Hash::make('toaster123'),

--- a/docker/pdfbox/install_pdfbox.sh
+++ b/docker/pdfbox/install_pdfbox.sh
@@ -20,7 +20,7 @@ echo Installing version $VERSION
 URL=https://dlcdn.apache.org/pdfbox/$VERSION/pdfbox-app-$VERSION.jar
 echo Downloading from $URL
 
-curl --fail -q -L $URL > pdfbox.jar > /usr/share/java/pdfbox.jar
+curl --fail -q -L $URL -o /usr/share/java/pdfbox.jar
 # </CURL>
 
 # <MAVEN> Version that builds our own from Maven

--- a/docker/pdfbox/install_pdfbox.sh
+++ b/docker/pdfbox/install_pdfbox.sh
@@ -14,7 +14,7 @@ set -o pipefail # Return code of a pipeline is the right-most failure. 0 if none
 
 MAJOR_VERSION=3
 
-VERSION=`curl --fail -s -l https://projects.apache.org/json/projects/pdfbox.json | jq -r "[ .release[] | select(.revision|test(\"^$MAJOR_VERSION\")).revision ][0]"`
+VERSION=`curl --fail -s -l https://projects.apache.org/json/projects/pdfbox.json | jq -r "[ .release[] | select(.name == \"Apache PDFBox\" and (.revision|test(\"^$MAJOR_VERSION\"))).revision ][0]"`
 
 echo Installing version $VERSION
 URL=https://dlcdn.apache.org/pdfbox/$VERSION/pdfbox-app-$VERSION.jar

--- a/docker/pdfbox/install_pdfbox.sh
+++ b/docker/pdfbox/install_pdfbox.sh
@@ -1,37 +1,46 @@
+#!/bin/bash
 
-#/bin/bash
-
-#### <Safety Net>
+#### <Safety Net>
 set -o errexit # Exit immediately if a pipeline returns non-zero.
 trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR # Print a helpful message if that happens
 set -o errtrace # Allow the above trap be inherited by all functions in the script.
 set -o pipefail # Return code of a pipeline is the right-most failure. 0 if none.
-#### </Safety Net>
-
-# <CURL> Version that just downloads the latest version
-# curl --fail -s -L https://api.github.com/repos/apache/pdfbox/git/refs/tags > /tmp/pdfbox.json
-# VERSION=`jq -r '.[] | select(.ref|test("tags/2")).ref' < /tmp/pdfbox.json | tail -1 | cut -d/ -f 3`
+#### </Safety Net>
 
 MAJOR_VERSION=3
 
-VERSION=`curl --fail -s -l https://projects.apache.org/json/projects/pdfbox.json | jq -r "[ .release[] | select(.name == \"Apache PDFBox\" and (.revision|test(\"^$MAJOR_VERSION\"))).revision ][0]"`
+API_RESPONSE=$(curl --fail -s -L https://projects.apache.org/json/projects/pdfbox.json) || {
+    echo "ERROR: Failed to contact Apache projects API." >&2
+    exit 1
+}
 
-echo Installing version $VERSION
-URL=https://dlcdn.apache.org/pdfbox/$VERSION/pdfbox-app-$VERSION.jar
-echo Downloading from $URL
+if [[ -z "$API_RESPONSE" ]]; then
+    echo "ERROR: Apache projects API returned an empty response." >&2
+    exit 1
+fi
 
-curl --fail -q -L $URL -o /usr/share/java/pdfbox.jar
-# </CURL>
+VERSION=$(echo "$API_RESPONSE" | jq -r "[ .release[] | select(.name == \"Apache PDFBox\" and (.revision|test(\"^$MAJOR_VERSION\"))).revision ][0]") || {
+    echo "ERROR: Failed to parse Apache projects API response." >&2
+    echo "$API_RESPONSE" | head -5 >&2
+    exit 1
+}
 
-# <MAVEN> Version that builds our own from Maven
-# cd /usr/src/pdfbox
-# mvn clean
-# mvn install
-# if [[ -f target/pdfbox-app-2.0.25.jar ]];
-# then
-#     cp target/pdfbox-app-2.0.25.jar /usr/share/java/pdfbox.jar
-# else
-#     echo "Compilation failed."
-#     exit 5
-# fi
-# </MAVEN>
+if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+    echo "ERROR: Could not determine PDFBox $MAJOR_VERSION.x version from Apache projects API." >&2
+    exit 1
+fi
+
+echo "Installing PDFBox version: ${VERSION}"
+URL="https://dlcdn.apache.org/pdfbox/${VERSION}/pdfbox-app-${VERSION}.jar"
+echo "Downloading from ${URL}"
+
+curl --fail -L "${URL}" -o /usr/share/java/pdfbox.jar
+curl --fail -L "${URL}.sha512" -o /tmp/pdfbox.jar.sha512
+
+EXPECTED_HASH=$(cat /tmp/pdfbox.jar.sha512)
+echo "${EXPECTED_HASH}  /usr/share/java/pdfbox.jar" | sha512sum -c - || {
+    echo "ERROR: SHA512 checksum verification failed — downloaded jar may be corrupt or tampered with." >&2
+    rm -f /usr/share/java/pdfbox.jar
+    exit 1
+}
+rm -f /tmp/pdfbox.jar.sha512


### PR DESCRIPTION
## Summary

### PDFBox
- Replace hardcoded URL+checksum with \`install_pdfbox.sh\`, which queries the Apache projects API for the latest 3.x release dynamically (3.0.4 was removed from the Apache CDN)
- Fix JBIG2 plugin releases polluting the version query (add \`name == \"Apache PDFBox\"\` filter); fix double-redirect bug in curl command

### Dockerfile
- Add \`jq\` to apk deps; add \`pdo_mysql\` and \`pdo_sqlite\` PHP extensions (missing vs Bloom baseline)
- Create all Laravel runtime directories upfront before composer/artisan run
- Move Vite build into the node stage so \`npm\` is available; copy built assets to PHP stage
- Regenerate autoloader after COPY so seeders are classmap-discoverable
- Trust all proxies so Laravel picks up X-Forwarded-Proto from reverse proxy

### ElasticSearch
- Remove \`sweepPages\` from \`IndexerInterface\` and ElasticSearch (method was unimplemented and caused fatal errors)
- Fix \`config:cache\` crash, PIT (point-in-time) leak, and silent sweep skip
- Enrich \`NoNodesAvailableException\` logging with connection scheme, credentials state, and SSL verification context to aid diagnostics

### CI / Staging
- Skip build/deploy for draft PRs; add \`ready_for_review\` trigger
- Seed staging DB on deploy; make user seeder idempotent
- Add \`migrate:status\` diagnostic on migration failure; improve container readiness failure output
- Deduplicate runs with workflow concurrency; protect production deploys from cancellation

## Test plan

- [x] Docker build succeeds in CI
- [x] Staging deploy runs
- [x] ElasticSearch indexing works without fatal errors
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)