### PR TITLE
🪳 Harden proxy trust and PDFBox supply-chain verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=https://thalium.aquarionics.com
+TRUSTED_PROXIES=172.16.0.0/12
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     unzip \
     curl \
     jq \
+    gnupg \
     openjdk21-jre-headless \
     imagemagick \
     ghostscript \

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -7,18 +7,14 @@ use Illuminate\Http\Request;
 
 class TrustProxies extends Middleware
 {
-    /**
-     * The trusted proxies for this application.
-     *
-     * @var array|string|null
-     */
-    protected $proxies = '*';
+    protected $proxies;
 
-    /**
-     * The headers that should be used to detect proxies.
-     *
-     * @var int
-     */
-    // After...
     protected $headers = (Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB);
-}// end class
+
+    // Default covers Docker's bridge network CIDR; override with TRUSTED_PROXIES env var (comma-separated CIDRs, or '*')
+    public function __construct()
+    {
+        $value = env('TRUSTED_PROXIES', '172.16.0.0/12');
+        $this->proxies = $value === '*' ? '*' : array_map('trim', explode(',', $value));
+    }
+}

--- a/docker/pdfbox/install_pdfbox.sh
+++ b/docker/pdfbox/install_pdfbox.sh
@@ -31,16 +31,38 @@ if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
 fi
 
 echo "Installing PDFBox version: ${VERSION}"
-URL="https://dlcdn.apache.org/pdfbox/${VERSION}/pdfbox-app-${VERSION}.jar"
-echo "Downloading from ${URL}"
 
-curl --fail -L "${URL}" -o /usr/share/java/pdfbox.jar
-curl --fail -L "${URL}.sha512" -o /tmp/pdfbox.jar.sha512
+CDN_BASE="https://dlcdn.apache.org/pdfbox/${VERSION}"
+CANONICAL_BASE="https://downloads.apache.org/pdfbox/${VERSION}"
+JAR_FILE="pdfbox-app-${VERSION}.jar"
+JAR_PATH="/usr/share/java/pdfbox.jar"
 
+echo "Downloading JAR from CDN..."
+curl --fail -L "${CDN_BASE}/${JAR_FILE}" -o "${JAR_PATH}"
+
+echo "Verifying SHA-512 checksum..."
+curl --fail -L "${CDN_BASE}/${JAR_FILE}.sha512" -o /tmp/pdfbox.jar.sha512
 EXPECTED_HASH=$(cat /tmp/pdfbox.jar.sha512)
-echo "${EXPECTED_HASH}  /usr/share/java/pdfbox.jar" | sha512sum -c - || {
+echo "${EXPECTED_HASH}  ${JAR_PATH}" | sha512sum -c - || {
     echo "ERROR: SHA512 checksum verification failed — downloaded jar may be corrupt or tampered with." >&2
-    rm -f /usr/share/java/pdfbox.jar
+    rm -f "${JAR_PATH}"
     exit 1
 }
 rm -f /tmp/pdfbox.jar.sha512
+
+# PGP signature fetched from canonical Apache server (different trust root from CDN mirror above)
+echo "Verifying PGP signature from canonical Apache server..."
+curl --fail -L "${CANONICAL_BASE}/${JAR_FILE}.asc" -o /tmp/pdfbox.jar.asc
+curl --fail -L "https://downloads.apache.org/pdfbox/KEYS" -o /tmp/pdfbox-KEYS
+
+GNUPGHOME=$(mktemp -d)
+export GNUPGHOME
+gpg --import /tmp/pdfbox-KEYS 2>/dev/null
+gpg --verify /tmp/pdfbox.jar.asc "${JAR_PATH}" || {
+    echo "ERROR: PGP signature verification failed — jar may be tampered with." >&2
+    rm -f "${JAR_PATH}"
+    rm -rf "${GNUPGHOME}"
+    exit 1
+}
+rm -rf "${GNUPGHOME}" /tmp/pdfbox.jar.asc /tmp/pdfbox-KEYS
+echo "PGP verification passed."


### PR DESCRIPTION
## Summary

- **TrustProxies**: replace blanket `'*'` with Docker bridge CIDR (`172.16.0.0/12`) as the default trusted proxy range; override via `TRUSTED_PROXIES` env var (comma-separated CIDRs, or `'*'` to restore previous behaviour)
- **install_pdfbox.sh**: add PGP signature verification — `.asc` file fetched from `downloads.apache.org` (canonical Apache server, separate trust root from the `dlcdn.apache.org` CDN mirror used for the JAR itself); SHA-512 check retained as a first-pass integrity check
- **Dockerfile**: add `gnupg` to apk deps to support PGP verification

## Test plan

- [ ] Docker build succeeds with `gnupg` added
- [ ] PDFBox installs and PGP verification passes in CI
- [ ] App picks up `X-Forwarded-Proto` correctly behind staging reverse proxy
- [ ] `TRUSTED_PROXIES=*` override works if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)