### PR TITLE
Fix broken CSS link left over from pre-Vite Mix build

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
-}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -33,7 +33,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png">
 
     <!-- Bootstrap core CSS -->
-<link rel="stylesheet" href="/css/app.css">
+@vite(['resources/sass/app.scss', 'resources/js/app.js'])
 
   </head>
   <body>
@@ -163,9 +163,6 @@
 
 
 </main><!-- /.container -->
-
-@vite(['resources/sass/app.scss', 'resources/js/app.js'])
-
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `resources/views/layouts/app.blade.php` hardcoded `<link rel="stylesheet" href="/css/app.css">`, a path from the old Laravel Mix build. Vite doesn't write there — it emits a hashed file under `/build/assets/` and injects the correct `<link>` itself via `@vite()`. That directive was present but sitting unused at the bottom of `<body>`, so the primary stylesheet 404'd everywhere while the app relied on inline/Bootstrap CDN fallback styling.
- Moved `@vite(['resources/sass/app.scss', 'resources/js/app.js'])` into `<head>`, in place of the dead link, so the compiled stylesheet loads correctly and without a flash of unstyled content.
- Removed `public/mix-manifest.json`, an orphaned Mix artifact whose entries (`/js/app.js`, `/css/app.css`) point at files that no longer exist and aren't referenced anywhere in the app.

## Context

Investigated "production thalium doesn't appear to be deploying vite resources accessibly." The Dockerfile/CI build and deploy Vite's `public/build` output correctly (confirmed via the multi-stage Docker build and the CI asset-extraction step), but the layout was still linking to the pre-migration Mix path instead of relying on `@vite()`, so the compiled CSS was never actually reachable in any environment, not just production.

## Test plan

- [ ] Deploy to staging and confirm `view-source:` / browser devtools show a `<link>` to `/build/assets/*.css` (not `/css/app.css`) and it returns 200
- [ ] Confirm Bootstrap styling renders correctly on a page load with a hard refresh (no cached stylesheet)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TB4FCM68f9X1k8riQVv81u)_