### PR TITLE
Fix PDFBox install 404 by falling back to Apache archive

### DIFF
--- a/docker/pdfbox/install_pdfbox.sh
+++ b/docker/pdfbox/install_pdfbox.sh
@@ -34,14 +34,25 @@ echo "Installing PDFBox version: ${VERSION}"
 
 CDN_BASE="https://dlcdn.apache.org/pdfbox/${VERSION}"
 CANONICAL_BASE="https://downloads.apache.org/pdfbox/${VERSION}"
+ARCHIVE_BASE="https://archive.apache.org/dist/pdfbox/${VERSION}"
 JAR_FILE="pdfbox-app-${VERSION}.jar"
 JAR_PATH="/usr/share/java/pdfbox.jar"
 
+# dlcdn.apache.org / downloads.apache.org only mirror the current release and
+# purge older ones as soon as a new version ships, so a version resolved from
+# the projects API can 404 there right after release. archive.apache.org
+# retains every release permanently, so fall back to it in that case.
+fetch_with_fallback() {
+    local primary="$1" path="$2" dest="$3"
+    curl --fail -L "${primary}/${path}" -o "${dest}" \
+        || curl --fail -L "${ARCHIVE_BASE}/${path}" -o "${dest}"
+}
+
 echo "Downloading JAR from CDN..."
-curl --fail -L "${CDN_BASE}/${JAR_FILE}" -o "${JAR_PATH}"
+fetch_with_fallback "${CDN_BASE}" "${JAR_FILE}" "${JAR_PATH}"
 
 echo "Verifying SHA-512 checksum..."
-curl --fail -L "${CDN_BASE}/${JAR_FILE}.sha512" -o /tmp/pdfbox.jar.sha512
+fetch_with_fallback "${CDN_BASE}" "${JAR_FILE}.sha512" /tmp/pdfbox.jar.sha512
 EXPECTED_HASH=$(cat /tmp/pdfbox.jar.sha512)
 echo "${EXPECTED_HASH}  ${JAR_PATH}" | sha512sum -c - || {
     echo "ERROR: SHA512 checksum verification failed — downloaded jar may be corrupt or tampered with." >&2
@@ -52,7 +63,7 @@ rm -f /tmp/pdfbox.jar.sha512
 
 # PGP signature fetched from canonical Apache server (different trust root from CDN mirror above)
 echo "Verifying PGP signature from canonical Apache server..."
-curl --fail -L "${CANONICAL_BASE}/${JAR_FILE}.asc" -o /tmp/pdfbox.jar.asc
+fetch_with_fallback "${CANONICAL_BASE}" "${JAR_FILE}.asc" /tmp/pdfbox.jar.asc
 curl --fail -L "https://downloads.apache.org/pdfbox/KEYS" -o /tmp/pdfbox-KEYS
 
 GNUPGHOME=$(mktemp -d)


### PR DESCRIPTION
## Summary

CI was failing on the `build-and-push` job: the Docker build errored with `curl: (22) The requested URL returned error: 404` while downloading the PDFBox jar in `docker/pdfbox/install_pdfbox.sh` ([run 29223419858](https://github.com/aquarion/thalium/actions/runs/29223419858/job/86732934032)).

`dlcdn.apache.org` and `downloads.apache.org` only mirror the *current* release of a project and purge older ones as soon as a new version ships. `install_pdfbox.sh` resolves the target version dynamically from the Apache projects API, so if that version has since been rotated off the live mirrors, the jar/checksum/signature downloads 404 even though the version itself is still valid.

- Add an `archive.apache.org` fallback (which retains every release permanently) for the jar download, its SHA-512 checksum, and its PGP signature, via a small `fetch_with_fallback` helper.
- No behavior change for the common case where the resolved version is still on the live mirrors.

## Test plan

- [ ] CI `build-and-push` job passes on this branch
- [x] `bash -n docker/pdfbox/install_pdfbox.sh` (syntax check)


---
_Generated by [Claude Code](https://claude.ai/code/session_011d8es2WjzAKXYY8PFqUvyt)_