### PR TITLE
Disable open user registration

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Route;
 //     return view('welcome');
 // });
 
-FacAuth::routes();
+FacAuth::routes(['register' => false]);
 
 Route::get('/auth/checkLogin', [Auth\CheckLoginController::class, 'checkLogin']);
 


### PR DESCRIPTION
## Summary
- `Auth::routes()` was registering `/register` with no gate, allowing anyone to self-register an account.
- Restricts routes to login/logout/password-reset by passing `['register' => false]`.
- The nav "Register" link already guards on `Route::has('register')`, so it disappears automatically.

## Test plan
- [x] `php artisan route:list` confirms no `register` routes remain
- [x] `php artisan test` — no new failures (pre-existing `MissingAppKeyException` in `ExampleTest` reproduced on main too, unrelated)